### PR TITLE
Enable debug blacklist

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -217,4 +217,9 @@ return [
         'Date' => Jenssegers\Date\Date::class
     ],
 
+    'debug_blacklist' => [
+        '_SERVER' => array_keys($_ENV),
+        '_ENV' => array_keys($_ENV),
+    ],
+
 ];


### PR DESCRIPTION
This PR adds environmental variables and `$_SERVER` variables to the debug blacklist. This makes it so that passwords and secrets are not leaked in error pages but show as e.g. "*****".

More info:
- https://stackoverflow.com/questions/46407009/how-to-hide-env-passwords-in-laravel-whoops-output
- https://github.com/laravel/framework/pull/21336